### PR TITLE
Ref chimera clean

### DIFF
--- a/lotus3
+++ b/lotus3
@@ -129,6 +129,7 @@ my $FaProTax        = undef; #faprotax -> functional annotations from taxonomy~~
 #my $citations = "$selfID: Hildebrand F, Tadeo RY, Voigt AY, Bork P, Raes J. 2014. LotuS: an efficient and user-friendly OTU processing pipeline. Microbiome 2: 30.\n";
 my $citations = "$selfID: Özkurt E, Fritscher J, et al. (2022) LotuS2: An ultrafast and highly accurate tool for amplicon sequencing analysis. Microbiome 10:176  doi:10.1186/s40168-022-01365-1.\n";
 my $noChimChk = 0; #deactivate all chimera checks 1=no nothing, 2=no denovo, 3=no ref; default = 0
+my $forceRefChim = 0; #force reference-based chimera check even for UPARSE(1)/DADA2(7); default 0=off, 1=on
 my $mainLogFile = "";
 my $osname      = $^O;
 my $verbosity = 1;
@@ -335,6 +336,7 @@ GetOptions(
 	"intargetDB=s"          => \$custKeepOTUDB,
 	"flash_param=s"         => \$flashCustom,
 	"deactivateChimeraCheck=i"=> \$noChimChk,
+	"refChimera=i"           => \$forceRefChim,
 	#"VsearchChimera=i"		=> \$useVsearch,
 	"useVsearch=i"          => \$useVsearch,
 	"removePhiX=i"          => \$doPhiX,
@@ -1567,7 +1569,8 @@ sub chimera_ref_rem($) {
 	my $iniEntries = cntFastaEntrs($otusFA);
 	my $progUsed = ""; my $cmd="";
 	my $outfile = $otusFA.".tmp.fa";
-    if ($ClusterPipe == 1 ||$ClusterPipe == 7 || $UCHIME_REFDB eq ""  || !-f $UCHIME_REFDB ||  $noChimChk == 1 ){
+    if ( $noChimChk == 1 || $UCHIME_REFDB eq "" || !-f $UCHIME_REFDB ||
+         ( ($ClusterPipe == 1 || $ClusterPipe == 7) && $forceRefChim == 0 ) ){
 		printL "No ref based chimera detection\n";
 		return $chimOut;
 	}

--- a/lotus3
+++ b/lotus3
@@ -1571,7 +1571,7 @@ sub chimera_ref_rem($) {
 	my $iniEntries = cntFastaEntrs($otusFA);
 	my $progUsed = ""; my $cmd="";
 	my $outfile = $otusFA.".tmp.fa";
-    if ( $noChimChk == 1 || $UCHIME_REFDB eq "" || !-f $UCHIME_REFDB ||
+    if ( $noChimChk == 1 || $noChimChk == 3 || $UCHIME_REFDB eq "" || !-f $UCHIME_REFDB ||
          ( ($ClusterPipe == 1 || $ClusterPipe == 7) && $forceRefChim == 0 ) ){
 		printL "No ref based chimera detection\n";
 		return $chimOut;

--- a/lotus3
+++ b/lotus3
@@ -130,6 +130,7 @@ my $FaProTax        = undef; #faprotax -> functional annotations from taxonomy~~
 my $citations = "$selfID: Özkurt E, Fritscher J, et al. (2022) LotuS2: An ultrafast and highly accurate tool for amplicon sequencing analysis. Microbiome 10:176  doi:10.1186/s40168-022-01365-1.\n";
 my $noChimChk = 0; #deactivate all chimera checks 1=no nothing, 2=no denovo, 3=no ref; default = 0
 my $forceRefChim = 0; #force reference-based chimera check even for UPARSE(1)/DADA2(7); default 0=off, 1=on
+my $chimRefDBcust = ""; #custom fasta for ref-based chimera check (overrides built-in UCHIME_REFDB); empty=use default
 my $mainLogFile = "";
 my $osname      = $^O;
 my $verbosity = 1;
@@ -337,6 +338,7 @@ GetOptions(
 	"flash_param=s"         => \$flashCustom,
 	"deactivateChimeraCheck=i"=> \$noChimChk,
 	"refChimera=i"           => \$forceRefChim,
+	"refChimeraDB=s"         => \$chimRefDBcust,
 	#"VsearchChimera=i"		=> \$useVsearch,
 	"useVsearch=i"          => \$useVsearch,
 	"removePhiX=i"          => \$doPhiX,
@@ -2464,6 +2466,10 @@ sub readPaths {    #read tax databases and setup correct usage
     }
     elsif ( $ampliconType eq "ITS1" ) {
         $UCHIME_REFDB = $UCHIME_REFits1;
+    }
+    if ( $chimRefDBcust ne "" ) {
+        $UCHIME_REFDB = $chimRefDBcust;
+        printL "Using custom reference DB for chimera checking:\n$UCHIME_REFDB\n", 0;
     }
     if ( !-e $UCHIME_REFDB ) {
         printL "Requested DB for uchime ref at\n$UCHIME_REFDB\ndoes not exist; LotuS will run without reference based ${OTU_prefix} chimera checking.\n","w";


### PR DESCRIPTION
Addresses Dr Ahn's report that reference-based chimera checking silently doesn't run for UPARSE/DADA2.

-refChimera (default 0): force the ref-based UCHIME pass for UPARSE/DADA2 when set to 1
-refChimeraDB: point the ref check at a custom fasta (path to wiring in KSGP later)
Fix: -deactivateChimeraCheck 3 was documented/handled in the summary header as "disable ref check" but the guard never tested for 3, so it silently had no effect — now fixed

Defaults unchanged; behaviour only differs when the new flags are set. Tested on the bundled Example dataset. Supersedes #<old PR number> (that branch inadvertently carried the dada2 fix).